### PR TITLE
Update transport tcp.c to avoid BSOD on failed connections

### DIFF
--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -411,6 +411,16 @@ NTSTATUS TCPConnect
                                                 &connaddr,
                                                 RemotePort));
 
+    if ((Status != STATUS_SUCCESS) && (Status != STATUS_PENDING)) { 
+    	TI_DbgPrint(DEBUG_TCP,
+                    ("no pcb from LibTCPConnect, clear ConnectRequest.\n")); 
+    	LockObject(Connection);
+    	RemoveTailList( &Connection->ConnectRequest); 
+	    // DLB - re-check, not sure this part is correct
+	    ExFreeToNPagedLookasideList( &TdiBucketLookasideList, Bucket );
+    	UnlockObject(Connection);
+    }
+    
     TI_DbgPrint(DEBUG_TCP,("[IP, TCPConnect] Leaving. Status = 0x%x\n", Status));
 
     return Status;


### PR DESCRIPTION
clear ConnectRequest elements referencing uninitialized pcb to avoid BSOD CORE-18982

## Purpose

On early failures like parameter issues LibTCPConnect does not create a pcb causing later Connection bucket items to create a BSOD

JIRA issue: [CORE-18982](https://jira.reactos.org/browse/CORE-18982)

## Proposed changes

added a small if branch that clears the ConnectRequest bucket if the call to LibTCPConnect does not return success or pending.
